### PR TITLE
Support the ability to specify a default template

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,13 @@ module.exports = function (grunt) {
           },
           env: {
             parameter: "value"
-          }
+          },
+          template_map: [
+            {
+              match: 'spec/fixtures/with_mapped_template.html',
+              template: 'default'
+            }
+          ]
         },
         files: [{
           expand: true,

--- a/lib/file.js
+++ b/lib/file.js
@@ -6,12 +6,10 @@
 
 module.exports = {
   find_closest_match: find_closest_match,
-  has_extension: has_extension,
-  file_template_map_setup: file_template_map_setup
+  has_extension: has_extension
 };
 
 var grunt = require("grunt");
-var _     = require("underscore");
 
 function find_closest_match (folder, filename) {
   if (!grunt.file.isDir(folder)) grunt.fail.warn("The folder " + folder + " does not exist.");
@@ -32,19 +30,6 @@ function build_pattern (folder, filename) {
   }
   var extension = has_extension(filename) ? "" : ".*";
   return folder + separator + filename + extension;
-}
-
-function file_template_map_setup (pattern_map) {
-  return _.reduce(pattern_map, function (agg, spec) {
-    if (!spec || !spec.match || !spec.template) {
-      return agg;
-    }
-    var matchedFiles = grunt.file.expand(spec.match);
-    for (var i = 0, length = matchedFiles.length; i < length; i++) {
-      agg[matchedFiles[i]] = spec.template;
-    }
-    return agg;
-  }, {});
 }
 
 function has_extension (filename) {

--- a/lib/file.js
+++ b/lib/file.js
@@ -6,10 +6,12 @@
 
 module.exports = {
   find_closest_match: find_closest_match,
-  has_extension: has_extension
+  has_extension: has_extension,
+  file_template_map_setup: file_template_map_setup
 };
 
 var grunt = require("grunt");
+var _     = require("underscore");
 
 function find_closest_match (folder, filename) {
   if (!grunt.file.isDir(folder)) grunt.fail.warn("The folder " + folder + " does not exist.");
@@ -30,6 +32,19 @@ function build_pattern (folder, filename) {
   }
   var extension = has_extension(filename) ? "" : ".*";
   return folder + separator + filename + extension;
+}
+
+function file_template_map_setup (pattern_map) {
+  return _.reduce(pattern_map, function (agg, spec) {
+    if (!spec || !spec.match || !spec.template) {
+      return agg;
+    }
+    var matchedFiles = grunt.file.expand(spec.match);
+    for (var i = 0, length = matchedFiles.length; i < length; i++) {
+      agg[matchedFiles[i]] = spec.template;
+    }
+    return agg;
+  }, {});
 }
 
 function has_extension (filename) {

--- a/lib/process_file.js
+++ b/lib/process_file.js
@@ -51,7 +51,7 @@ function setup (config) {
 
     var content = bundle(compile(input_file, env), header);
 
-    if (env.template && join(options.templates, env.template) !== input_file) {
+    if (env.template && join(options.templates || '', env.template) !== input_file) {
       content = bundle(wrap(env.template, content), header);
     }
 

--- a/lib/process_file.js
+++ b/lib/process_file.js
@@ -22,9 +22,10 @@ function setup (config) {
   var options            = config.options || {},
       read_header        = config.read_header,
       compile            = config.compile,
-      find_closest_match = config.find_closest_match;
+      find_closest_match = config.find_closest_match,
+      file_template_map  = config.file_template_map || {};
 
-  var process_page     = process_file.bind(null, "."),
+  var process_page     = process_file.bind(null, ""),
       process_partial  = process_file.bind(null, options.partials),
       process_template = process_file.bind(null, options.templates),
       processed        = {};
@@ -51,8 +52,9 @@ function setup (config) {
 
     var content = bundle(compile(input_file, env), header);
 
-    if (env.template && join(options.templates || '', env.template) !== input_file) {
-      content = bundle(wrap(env.template, content), header);
+    header.template = header.template || file_template_map[input_file];
+    if (header.template) {
+      content = bundle(wrap(header.template, content), header);
     }
 
     return content;

--- a/lib/process_file.js
+++ b/lib/process_file.js
@@ -22,7 +22,7 @@ function setup (config) {
       read_header        = config.read_header,
       compile            = config.compile,
       find_closest_match = config.find_closest_match,
-      file_template_map  = config.file_template_map || {};
+      resolve_template   = config.resolve_template;
 
   var process_page     = process_file.bind(null, ""),
       process_partial  = process_file.bind(null, options.partials),
@@ -51,7 +51,8 @@ function setup (config) {
 
     var content = bundle(compile(input_file, env), header);
 
-    header.template = header.template || file_template_map[input_file];
+    resolve_template(header, input_file);
+
     if (header.template) {
       content = bundle(wrap(header.template, content), header);
     }

--- a/lib/process_file.js
+++ b/lib/process_file.js
@@ -15,6 +15,7 @@
 module.exports = setup;
 
 var _ = require("underscore");
+var join = require("path").join;
 
 function setup (config) {
 
@@ -50,8 +51,8 @@ function setup (config) {
 
     var content = bundle(compile(input_file, env), header);
 
-    if (header.template) {
-      content = bundle(wrap(header.template, content), header);
+    if (env.template && join(options.templates, env.template) !== input_file) {
+      content = bundle(wrap(env.template, content), header);
     }
 
     return content;

--- a/lib/process_file.js
+++ b/lib/process_file.js
@@ -15,7 +15,6 @@
 module.exports = setup;
 
 var _ = require("underscore");
-var join = require("path").join;
 
 function setup (config) {
 

--- a/lib/template_resolver.js
+++ b/lib/template_resolver.js
@@ -1,0 +1,34 @@
+"use strict";
+
+/*
+ * A set of functions that manipulate and read files and filepaths
+ */
+
+module.exports = setup;
+
+var grunt = require("grunt");
+var _     = require("underscore");
+
+function setup (pattern_map) {
+  var file_to_template = build_map(pattern_map || []);
+
+  return resolve_template;
+
+  function resolve_template (header, input_file) {
+    if (!header || header && header.template || !input_file) return;
+
+    header.template = file_to_template[input_file];
+  }
+
+  function build_map (pattern_map) {
+    return _.reduce(pattern_map, function (agg, spec) {
+      if (!spec || !spec.match || !spec.template) return agg;
+
+      var matchedFiles = grunt.file.expand(spec.match);
+      for (var i = 0, length = matchedFiles.length; i < length; i++) {
+        agg[matchedFiles[i]] = spec.template;
+      }
+      return agg;
+    }, {});
+  }
+}

--- a/spec/expected/with_mapped_template.html
+++ b/spec/expected/with_mapped_template.html
@@ -1,0 +1,1 @@
+This is a template. This page has a mapped template.

--- a/spec/fixtures/with_mapped_template.html
+++ b/spec/fixtures/with_mapped_template.html
@@ -1,0 +1,1 @@
+This page has a mapped template.

--- a/spec/process_file_spec.js
+++ b/spec/process_file_spec.js
@@ -153,7 +153,7 @@ describe("process_file", function () {
       expect(process_file(page_name).toString()).toEqual(template_name + page_content);
     });
 
-    it("detects circular dependencies in templates", function() {
+    it("prevents circular dependencies in templates", function() {
       var process_file = process_file_setup({
         read_header: function (filename) {
           return {template: template_name};
@@ -164,7 +164,7 @@ describe("process_file", function () {
         find_closest_match: function (folder, name) { return name; }
       });
 
-      expect(function() {process_file(page_name)}).toThrow(circular_error);
+      expect(process_file(page_name).toString()).toEqual(template_name + page_content);
     });
 
     it("the wrapped page exposes its header fields", function() {

--- a/spec/process_file_spec.js
+++ b/spec/process_file_spec.js
@@ -4,6 +4,7 @@ var random = require("./random");
 var file = require("../lib/file")
 var process_file_setup = require("../lib/process_file");
 var trim = require("./trim");
+var noop = function () {};
 
 describe("process_file", function () {
 
@@ -16,7 +17,8 @@ describe("process_file", function () {
       var process_file = process_file_setup({
         read_header: function () { return {}; },
         compile: function () { return content; },
-        find_closest_match: function () { return ""; }
+        find_closest_match: function () { return ""; },
+        resolve_template: noop
       });
 
       expect(process_file().toString()).toEqual(content);
@@ -30,7 +32,8 @@ describe("process_file", function () {
       var process_file = process_file_setup({
         read_header: function () { return { title: title }; },
         compile: function () { return ""; },
-        find_closest_match: function () { return ""; }
+        find_closest_match: function () { return ""; },
+        resolve_template: noop
       });
 
       expect(process_file().title).toEqual(title);
@@ -51,7 +54,8 @@ describe("process_file", function () {
         compile: function (name, params) {
           return name === page_name ? page(params) : partial_content;
         },
-        find_closest_match: function (folder, name) { return name; }
+        find_closest_match: function (folder, name) { return name; },
+        resolve_template: noop
       });
 
       expect(process_file(page_name).toString()).toEqual(partial_content);
@@ -65,7 +69,8 @@ describe("process_file", function () {
         compile: function (name, params) {
           return params.include(partial_name);
         },
-        find_closest_match: function (folder, name) { return name; }
+        find_closest_match: function (folder, name) { return name; },
+        resolve_template: noop
       });
 
       expect(function () { process_file(partial_name); }).toThrow(circular_error);
@@ -83,7 +88,8 @@ describe("process_file", function () {
             params.include(partial_name);
           }
         },
-        find_closest_match: function (folder, name) { return name; }
+        find_closest_match: function (folder, name) { return name; },
+        resolve_template: noop
       });
 
       expect(function () { process_file(page_name); }).not.toThrow();
@@ -116,7 +122,8 @@ describe("process_file", function () {
               return template_content.replace(partial_placeholder, partial_content);
             }
           },
-          find_closest_match: function (folder, name) { return name; }
+          find_closest_match: function (folder, name) { return name; },
+          resolve_template: noop
         });
 
         expect(process_file(page_name).toString()).toEqual(page_content + template_name + partial_content);
@@ -147,7 +154,8 @@ describe("process_file", function () {
         compile: function (name, params) {
           return name === page_name ? page_content : compile_template(name, params);
         },
-        find_closest_match: function (folder, name) { return name; }
+        find_closest_match: function (folder, name) { return name; },
+        resolve_template: noop
       });
 
       expect(process_file(page_name).toString()).toEqual(template_name + page_content);
@@ -161,7 +169,8 @@ describe("process_file", function () {
         compile: function (name, params) {
           return name === page_name ? page_content : compile_template(name, params);
         },
-        find_closest_match: function (folder, name) { return name; }
+        find_closest_match: function (folder, name) { return name; },
+        resolve_template: noop
       });
 
       expect(function() {process_file(page_name)}).toThrow(circular_error);
@@ -175,7 +184,8 @@ describe("process_file", function () {
         compile: function (name, params) {
           return name === page_name ? page_content : compile_template(name, params);
         },
-        find_closest_match: function (folder, name) { return name; }
+        find_closest_match: function (folder, name) { return name; },
+        resolve_template: noop
       });
 
       expect(process_file(page_name).param).toEqual(page_param);
@@ -196,7 +206,8 @@ describe("process_file", function () {
                                    .replace(param_placeholder, params.document.param);
           }
         },
-        find_closest_match: function (folder, name) { return name; }
+        find_closest_match: function (folder, name) { return name; },
+        resolve_template: noop
       });
 
       expect(process_file(page_name).toString()).toEqual(template_name + page_content + page_param);

--- a/spec/process_file_spec.js
+++ b/spec/process_file_spec.js
@@ -153,7 +153,7 @@ describe("process_file", function () {
       expect(process_file(page_name).toString()).toEqual(template_name + page_content);
     });
 
-    it("prevents circular dependencies in templates", function() {
+    it("detects circular dependencies in templates", function() {
       var process_file = process_file_setup({
         read_header: function (filename) {
           return {template: template_name};
@@ -164,7 +164,7 @@ describe("process_file", function () {
         find_closest_match: function (folder, name) { return name; }
       });
 
-      expect(process_file(page_name).toString()).toEqual(template_name + page_content);
+      expect(function() {process_file(page_name)}).toThrow(circular_error);
     });
 
     it("the wrapped page exposes its header fields", function() {

--- a/spec/template_resolver_spec.js
+++ b/spec/template_resolver_spec.js
@@ -1,0 +1,123 @@
+"use strict";
+
+describe("template_resolver", function () {
+  var grunt = require("grunt");
+  var template_resolver_setup = require("../lib/template_resolver");
+
+  it("does not throw without parameters", function() {
+    expect(function () {
+      var resolve_template = template_resolver_setup();
+      resolve_template();
+    }).not.toThrow();
+  });
+
+  describe("with empty map", function () {
+    var resolve_template = template_resolver_setup([]);
+    it("won't overwrite existing template", function () {
+      var header = { template: 'sometemplate' };
+      resolve_template(header, 'somefile');
+      expect(header.template).toBe('sometemplate');
+    });
+
+    it("won't set a template", function () {
+      var header = {};
+      resolve_template(header, 'somefile');
+      expect(header.template).toBeUndefined();
+    });
+  });
+
+  describe("with a single mapping", function () {
+    var resolve_template = template_resolver_setup([{
+      match:'spec/expected/with_*',
+      template:'only_template'
+    }]);
+    describe("and a matching file", function () {
+      it("won't overwrite existing template", function () {
+        var header = { template: 'sometemplate' };
+        resolve_template(header, 'spec/expected/with_header.html');
+        expect(header.template).toBe('sometemplate');
+      });
+
+      it("will set mapped template", function () {
+        var header = {};
+        resolve_template(header, 'spec/expected/with_header.html');
+        expect(header.template).toBe('only_template');
+      });
+    });
+    describe("and a non-matching file", function () {
+      it("won't overwrite existing template", function () {
+        var header = { template: 'sometemplate' };
+        resolve_template(header, 'spec/expected/html_only.html');
+        expect(header.template).toBe('sometemplate');
+      });
+
+      it("won't set a template", function () {
+        var header = {};
+        resolve_template(header, 'spec/expected/html_only.html');
+        expect(header.template).toBeUndefined();
+      });
+    });
+  });
+
+  describe("with multiple mappings", function () {
+    var resolve_template = template_resolver_setup([{
+      match:'spec/expected/*_only.html',
+      template:'first_template'
+    },{
+      match:'spec/expected/*dot*.html',
+      template:'second_template'
+    }]);
+    describe("and a file matching only first mapping", function () {
+      it("won't overwrite existing template", function () {
+        var header = { template: 'sometemplate' };
+        resolve_template(header, 'spec/expected/html_only.html');
+        expect(header.template).toBe('sometemplate');
+      });
+
+      it("will set mapped template", function () {
+        var header = {};
+        resolve_template(header, 'spec/expected/html_only.html');
+        expect(header.template).toBe('first_template');
+      });
+    });
+    describe("and a file matching only second mapping", function () {
+      it("won't overwrite existing template", function () {
+        var header = { template: 'sometemplate' };
+        resolve_template(header, 'spec/expected/custom_dotvar.html');
+        expect(header.template).toBe('sometemplate');
+      });
+
+      it("will set mapped template", function () {
+        var header = {};
+        resolve_template(header, 'spec/expected/custom_dotvar.html');
+        expect(header.template).toBe('second_template');
+      });
+    });
+    describe("and a file matching multiple mappings", function () {
+      it("won't overwrite existing template", function () {
+        var header = { template: 'sometemplate' };
+        resolve_template(header, 'spec/expected/dot_only.html');
+        expect(header.template).toBe('sometemplate');
+      });
+
+      it("will set mapped template to last mapping", function () {
+        var header = {};
+        resolve_template(header, 'spec/expected/dot_only.html');
+        expect(header.template).toBe('second_template');
+      });
+    });
+    describe("and a non-matching file", function () {
+      it("won't overwrite existing template", function () {
+        var header = { template: 'sometemplate' };
+        resolve_template(header, 'spec/expected/with_header.html');
+        expect(header.template).toBe('sometemplate');
+      });
+
+      it("won't set a template", function () {
+        var header = {};
+        resolve_template(header, 'spec/expected/with_header.html');
+        expect(header.template).toBeUndefined();
+      });
+    });
+  });
+});

--- a/tasks/stencil.js
+++ b/tasks/stencil.js
@@ -13,6 +13,7 @@ var file = require("../lib/file");
 var parse_setup = require("../lib/parse");
 var compilers_setup = require("../lib/compilers");
 var process_file_setup = require("../lib/process_file");
+var template_resolver_setup = require("../lib/template_resolver");
 
 var _ = require("underscore");
 
@@ -43,12 +44,14 @@ module.exports = function(grunt) {
       ]
     });
 
+    var resolve_template = template_resolver_setup(options.template_map);
+
     var process_file = new process_file_setup({
       options: options,
       compile: compile,
       read_header: _.compose(parse.header, grunt.file.read),
       find_closest_match: file.find_closest_match,
-      file_template_map: file.file_template_map_setup(options.template_map)
+      resolve_template: resolve_template
     });
 
     this.files.forEach(function (mapping) {

--- a/tasks/stencil.js
+++ b/tasks/stencil.js
@@ -27,6 +27,7 @@ module.exports = function(grunt) {
       templates: ".",
       env: {},
       dot_template_settings: {},
+      template_map: [],
       meta_data_separator: "\n\n"
     });
 
@@ -46,7 +47,8 @@ module.exports = function(grunt) {
       options: options,
       compile: compile,
       read_header: _.compose(parse.header, grunt.file.read),
-      find_closest_match: file.find_closest_match
+      find_closest_match: file.find_closest_match,
+      file_template_map: file.file_template_map_setup(options.template_map)
     });
 
     this.files.forEach(function (mapping) {


### PR DESCRIPTION
I wanted to avoid putting the same `{template: '...'}` in all my markdown files, so I changed it so that you can specify a template in the default environment and it will use it. It also stops the use of a template on the template file itself (solving most of the circular reference situations). Updated the tests for this change.

Also worth noting that your fixture test fails with `marked@0.2.10` as they added header IDs. Didn't want to update the test because it will fail for v0.2.9. You should probably specify the exact version of `marked` to use.
