### PR TITLE
have env read from json files if name is passed as string

### DIFF
--- a/tasks/stencil.js
+++ b/tasks/stencil.js
@@ -30,6 +30,10 @@ module.exports = function(grunt) {
       meta_data_separator: /\r?\n\r?\n/
     });
 
+    if ("string" === typeof options.env) {
+      options.env = grunt.file.readJSON(options.env);
+    }
+
     var parse = parse_setup(options.meta_data_separator);
 
     var compile =  compilers_setup({


### PR DESCRIPTION
I wanted to read env from a file whose name is determined during runtime, depending on other command line settings. So with the proposed change, I can now provide

env: path.join('<%= configHome %>', '<%= grunt.config("target") %>.json'),

and the task will call grunt.file.readJSON() with env as argument. The beauty is that calls to this.options evaluate templates, as opposed to my previous attempt with

env: grunt.file.readJSON(path.join('<%= configHome %>', '<%= grunt.config("target") %>.json'))

where the filename was taken verbatim ('<%= ...') and templates were not evaluated.
